### PR TITLE
Define xrange() for Pyhton 3

### DIFF
--- a/changelinktype.py
+++ b/changelinktype.py
@@ -2,6 +2,12 @@
 from __future__ import print_function
 import sys
 
+try:
+	xrange          # Python 2
+except NameError:
+	xrange = range  # Pyhton 3
+
+
 def u32(a, i):
 	return a[i] | (a[i+1] << 8) | (a[i+2] << 16) | (a[i+3] << 32)
 def wu32(a, i, v):


### PR DESCRIPTION
__xrange()__ is called on line 36 but it was removed in Python 3 in favor of __range()__.